### PR TITLE
feat: add import-service

### DIFF
--- a/import-service/.gitignore
+++ b/import-service/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+jspm_packages
+
+.webpack
+.serverless
+.DS_Store
+
+.env
+
+package-lock.json

--- a/import-service/babel.config.js
+++ b/import-service/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+};

--- a/import-service/handler.js
+++ b/import-service/handler.js
@@ -1,0 +1,4 @@
+import { importProductsFile } from './src/handlers/importProductsFile';
+import { importFileParser } from './src/handlers/importFileParser';
+
+export { importProductsFile, importFileParser };

--- a/import-service/package.json
+++ b/import-service/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "import-service",
+  "version": "1.0.0",
+  "description": "Import-service for Book shop",
+  "main": "handler.js",
+  "scripts": {
+    "test": "jest",
+    "deploy": "npm run test && sls deploy",
+    "deploy:notest": "sls deploy"
+  },
+  "author": "asm",
+  "license": "ISC",
+  "dependencies": {
+    "aws-sdk": "^2.792.0",
+    "aws-sdk-mock": "^5.1.0",
+    "babel": "^6.23.0",
+    "babel-core": "^6.26.3",
+    "babel-preset-es2015": "^6.24.1",
+    "csv-parser": "^2.3.3"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.12.1",
+    "jest": "^26.6.1",
+    "serverless-webpack": "^5.3.5",
+    "webpack": "^4.44.1",
+    "webpack-node-externals": "^2.5.0"
+  }
+}

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -1,0 +1,50 @@
+service: import-service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+
+  iamRoleStatements:
+    - Effect: 'Allow'
+      Action: 's3:ListBucket'
+      Resource:
+        - 'arn:aws:s3:::spitai-import'
+    - Effect: 'Allow'
+      Action: 's3:*'
+      Resource:
+        - 'arn:aws:s3:::spitai-import/*'
+
+plugins:
+  - serverless-webpack
+
+custom:
+  webpack:
+    webpackConfig: 'webpack.config.js'
+    includeModules: true
+    excludeFiles: src/**/*.test.js
+
+functions:
+  importProductsFile:
+    handler: handler.importProductsFile
+    events:
+      - http:
+          method: get
+          path: import
+          cors: true
+          request:
+            parameters:
+              querystrings:
+                name: true
+  importFileParser:
+    handler: handler.importFileParser
+    events:
+      - s3:
+          bucket: 'spitai-import'
+          event: 's3:ObjectCreated:*'
+          rules:
+            - prefix: 'uploaded/'
+              suffix: '.csv'
+          existing: true
+              

--- a/import-service/src/constants/index.js
+++ b/import-service/src/constants/index.js
@@ -1,0 +1,21 @@
+export const DEFAULT_HEADERS = {
+  headers: {
+    'Access-Control-Allow-Methods': '*',
+    'Access-Control-Allow-Origin': '*',
+  },
+};
+
+export const IMPORT_BUCKET_NAME = 'spitai-import';
+
+export const UPLOADED_DIRNAME = 'uploaded';
+export const PARSED_DIRNAME = 'parsed';
+
+export const S3_CONFIG = {
+  region: 'eu-west-1',
+};
+
+export const S3_DEFAULT_PARAMS = {
+  Expires: 60,
+};
+
+export const S3_PUT_OPERATION = 'putObject';

--- a/import-service/src/handlers/__test__/handlers.test.js
+++ b/import-service/src/handlers/__test__/handlers.test.js
@@ -1,0 +1,27 @@
+import * as AWS from 'aws-sdk';
+import * as AWSMock from 'aws-sdk-mock';
+
+import { importProductsFile } from '../importProductsFile';
+import { S3_PUT_OPERATION } from '../../constants';
+import { getResponseObject, getS3ImportParams } from '../../utils';
+
+describe('AWS Lambda handlers tests', () => {
+  const testName = 'test.csv';
+  const getEventMock = name => ({
+    queryStringParameters: { name },
+  });
+
+  describe('importProductsFile handler tests', () => {
+    it('should return correct response', async () => {
+      AWSMock.setSDKInstance(AWS);
+      AWSMock.mock('S3', 'getSignedUrl', (operation, params) => {
+        expect(operation).toEqual(S3_PUT_OPERATION);
+        expect(params).toEqual(getS3ImportParams(testName));
+      });
+
+      const eventMock = getEventMock(testName);
+      const result = await importProductsFile(eventMock);
+      expect(result.statusCode).toEqual(200);
+    });
+  });
+});

--- a/import-service/src/handlers/importFileParser.js
+++ b/import-service/src/handlers/importFileParser.js
@@ -1,0 +1,42 @@
+import * as csv from 'csv-parser';
+
+import {
+  getS3Conn,
+  getS3ParseParams,
+  getS3CopyParams,
+  getResponseObject,
+} from '../utils';
+
+export const importFileParser = async event => {
+  try {
+    await new Promise((resolve, reject) => {
+      for (const record of event.Records) {
+        const s3 = getS3Conn();
+        const recordKey = record.s3.object.key;
+        const params = getS3ParseParams(recordKey);
+        s3.getObject(params)
+          .createReadStream()
+          .pipe(csv())
+          .on('data', data => {
+            console.log('Data:', data);
+          })
+          .on('end', async () => {
+            const copyParams = getS3CopyParams(recordKey);
+            await s3.copyObject(copyParams).promise();
+            await s3.deleteObject(params).promise();
+            resolve();
+          })
+          .on('error', error => {
+            console.log('Error:', error);
+            reject(error);
+          });
+      }
+    });
+
+    return getResponseObject(202);
+  } catch (e) {
+    return getResponseObject(500, {
+      error: 'Internal server error',
+    });
+  }
+};

--- a/import-service/src/handlers/importProductsFile.js
+++ b/import-service/src/handlers/importProductsFile.js
@@ -1,0 +1,18 @@
+import { S3_PUT_OPERATION } from '../constants';
+import { getS3Conn, getS3ImportParams, getResponseObject } from '../utils';
+
+export const importProductsFile = async event => {
+  const {
+    queryStringParameters: { name },
+  } = event;
+  const s3 = getS3Conn();
+  const params = getS3ImportParams(name);
+  try {
+    const signedUrl = await s3.getSignedUrl(S3_PUT_OPERATION, params);
+    return getResponseObject(200, signedUrl);
+  } catch (e) {
+    return getResponseObject(500, {
+      error: 'Internal server error',
+    });
+  }
+};

--- a/import-service/src/utils/index.js
+++ b/import-service/src/utils/index.js
@@ -1,0 +1,36 @@
+import * as AWS from 'aws-sdk';
+
+import {
+  DEFAULT_HEADERS,
+  S3_CONFIG,
+  S3_DEFAULT_PARAMS,
+  IMPORT_BUCKET_NAME,
+  UPLOADED_DIRNAME,
+  PARSED_DIRNAME,
+} from '../constants';
+
+export const getResponseObject = (statusCode, body) => ({
+  statusCode,
+  ...(body && { body: JSON.stringify(body) }),
+  ...DEFAULT_HEADERS,
+});
+
+export const getS3Conn = () => new AWS.S3(S3_CONFIG);
+
+export const getS3ImportParams = name => ({
+  ...S3_DEFAULT_PARAMS,
+  Bucket: IMPORT_BUCKET_NAME,
+  Key: `${UPLOADED_DIRNAME}/${name}`,
+  ContentType: 'text/csv',
+});
+
+export const getS3ParseParams = recordKey => ({
+  Bucket: IMPORT_BUCKET_NAME,
+  Key: recordKey,
+});
+
+export const getS3CopyParams = recordKey => ({
+  Bucket: IMPORT_BUCKET_NAME,
+  CopySource: `${IMPORT_BUCKET_NAME}/${recordKey}`,
+  Key: recordKey.replace(UPLOADED_DIRNAME, PARSED_DIRNAME),
+});

--- a/import-service/webpack.config.js
+++ b/import-service/webpack.config.js
@@ -1,0 +1,12 @@
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+
+module.exports = {
+  entry: slsw.lib.entries,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  devtool: slsw.lib.webpack.isLocal
+    ? 'cheap-module-eval-source-map'
+    : 'source-map',
+  target: 'node',
+  externals: [nodeExternals()],
+};


### PR DESCRIPTION
### Task 5 (AWS Simple Storage Service - S3)

**Main tasks:**
✅ Task 5.1 completed

- `importProductsFile`: https://n5cx87r831.execute-api.eu-west-1.amazonaws.com/dev/import?name=test.csv

✅ Task 5.2 completed

<img width="1158" alt="Screen Shot 2020-11-15 at 16 42 23" src="https://user-images.githubusercontent.com/72622007/99186480-9d577e80-2761-11eb-992b-0acb35cbfb80.png">

✅ Frontend application is integrated with import service

- Link to PR in FE repo: https://github.com/spitaI/nodejs-aws-fe/pull/5

**Additional tasks:**
✅ async/await is used in lambda functions
✅ importProductsFile lambda is covered by unit tests
✅ At the end of the stream the lambda function should move the file from the uploaded folder into the parsed folder

**Done:** 14.11.2020 / deadline 15.11.2020
**Score:** 8/8