### PR TITLE
feat: add bff-service

### DIFF
--- a/bff-service/.ebextensions/environmentvariables.config
+++ b/bff-service/.ebextensions/environmentvariables.config
@@ -1,0 +1,4 @@
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    cart: 'https://ziwgp32rgd.execute-api.eu-west-1.amazonaws.com/dev/api'
+    products: 'https://mb8luvjk4i.execute-api.eu-west-1.amazonaws.com/dev'

--- a/bff-service/.ebextensions/nodecommand.config
+++ b/bff-service/.ebextensions/nodecommand.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:nodejs:
+    NodeCommand: "npm start"

--- a/bff-service/.gitignore
+++ b/bff-service/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+jspm_packages
+dist
+
+package-lock.json
+yarn.lock
+
+.DS_Store
+.env
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/bff-service/constants/index.js
+++ b/bff-service/constants/index.js
@@ -1,0 +1,6 @@
+export const CACHE_CONFIG = [
+  {
+    path: '/products',
+    methods: ['GET'],
+  },
+];

--- a/bff-service/middlewares/cache.js
+++ b/bff-service/middlewares/cache.js
@@ -1,0 +1,27 @@
+import { response } from 'express';
+import NodeCache from 'node-cache';
+
+import { shouldUseCache } from '../utils';
+
+const cache = new NodeCache();
+
+export const cachedResponseMiddleware = (req, res, next) => {
+  const { originalUrl, method } = req;
+  if (!shouldUseCache(originalUrl, method)) return next();
+
+  const cachedResponse = cache.get(`${method}:${originalUrl}`);
+  if (!cachedResponse) return next();
+
+  return res
+    .set(cachedResponse.headers)
+    .status(cachedResponse.status)
+    .json(cachedResponse.data);
+};
+
+export const cacheMiddleware = (req, res, next) => {
+  const { originalUrl, method, serviceResponse } = req;
+  if (!serviceResponse || !shouldUseCache(originalUrl, method)) return next();
+
+  const { headers, status, data } = serviceResponse;
+  cache.set(`${method}:${originalUrl}`, { headers, status, data }, 120);
+};

--- a/bff-service/middlewares/index.js
+++ b/bff-service/middlewares/index.js
@@ -1,0 +1,1 @@
+export * from './cache';

--- a/bff-service/package.json
+++ b/bff-service/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "bff-service",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "build": "webpack",
+    "start": "npm run build && node dist/main.js",
+    "dev": "babel-node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "asm",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.21.0",
+    "dotenv": "^8.2.0",
+    "express": "~4.16.1",
+    "node-cache": "^5.1.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.12.10",
+    "@babel/core": "^7.12.10",
+    "@babel/node": "^7.12.10",
+    "@babel/preset-env": "^7.12.10",
+    "webpack": "^4.44.1",
+    "webpack-cli": "^4.2.0"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env"
+    ]
+  }
+}

--- a/bff-service/server.js
+++ b/bff-service/server.js
@@ -1,0 +1,57 @@
+import Express from 'express';
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+import { cachedResponseMiddleware, cacheMiddleware } from './middlewares';
+import { getServiceUrl } from './utils';
+
+dotenv.config();
+
+const PORT = process.env.PORT || 3000;
+const app = Express();
+
+app.use(Express.json());
+app.use(Express.urlencoded());
+
+app.use(cachedResponseMiddleware);
+
+app.all('/:serviceName*', (req, res, next) => {
+  try {
+    const { serviceName } = req.params;
+    const serviceUrl = getServiceUrl(serviceName);
+    const servicePath = req.originalUrl.replace(`/${serviceName}`, '');
+    const recipientUrl = `${serviceUrl}${servicePath}`;
+
+    axios({
+      method: req.method,
+      url: recipientUrl,
+      headers: { ...req.headers, host: '' },
+      ...(Object.keys(req.body || {}).length > 0 && { data: req.body }),
+    })
+      .then(r => {
+        req.serviceResponse = r;
+        next();
+      })
+      .catch(e => next(e));
+  } catch (e) {
+    next(e);
+  }
+});
+
+app.use(cacheMiddleware);
+
+app.use((req, res, next) => {
+  const response = req.serviceResponse;
+  if (!response) return next(new Error('Error'));
+  return res.set(response.headers).status(response.status).json(response.data);
+});
+
+app.use((error, req, res, next) => {
+  if (!error.response) return res.status(500).json({ error: error.message });
+  const { headers, status, data } = error.response;
+  return res.set(headers).status(status).json(data);
+});
+
+app.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`);
+});

--- a/bff-service/utils/index.js
+++ b/bff-service/utils/index.js
@@ -1,0 +1,18 @@
+import { CACHE_CONFIG } from '../constants';
+
+export const getServiceUrl = serviceName => {
+  const serviceUrl = process.env[serviceName];
+  if (!serviceUrl) {
+    throw new Error('Cannot process request');
+  }
+
+  return serviceUrl;
+};
+
+export const shouldUseCache = (originalUrl, method) => {
+  for (const c of CACHE_CONFIG) {
+    if (originalUrl.startsWith(c.path) && c.methods.includes(method))
+      return true;
+  }
+  return false;
+};

--- a/bff-service/webpack.config.js
+++ b/bff-service/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  entry: './server.js',
+  mode: 'production',
+  devtool: 'source-map',
+  target: 'node',
+};


### PR DESCRIPTION
### Task 9 (Backend For Frontend)

**Main tasks:**
✅ Task 9.1 completed
✅ Task 9.2 completed

- Link to products api endpoint: https://mb8luvjk4i.execute-api.eu-west-1.amazonaws.com/dev/products
- Link to cart api endpoint: https://ziwgp32rgd.execute-api.eu-west-1.amazonaws.com/dev/api/profile/cart
- Link to bff-service: http://spitai-bff-api-bff-env.eu-west-1.elasticbeanstalk.com


- Example of products via bff: http://spitai-bff-api-bff-env.eu-west-1.elasticbeanstalk.com/products/products
- Example of cart via bff: http://spitai-bff-api-bff-env.eu-west-1.elasticbeanstalk.com/cart/profile/cart

For non-existing recipients bff-service should return 502 status code and a message "Cannot process request": http://spitai-bff-api-bff-env.eu-west-1.elasticbeanstalk.com/test

**Additional tasks:**
✅ Add a cache at the bff-service level for a request to the getProductsList function of the product-service. The cache should expire in 2 minutes

You can test caching by creating a product here https://dg40l25no04i2.cloudfront.net/admin/product-form, and wait for about 2 minutes for the product appearance in here http://spitai-bff-api-bff-env.eu-west-1.elasticbeanstalk.com/products/products

**Done:** 13.12.2020 / deadline 13.12.2020
**Score:** 6/7